### PR TITLE
Add support for macOS Darwin

### DIFF
--- a/data/osfamily/Darwin.yaml
+++ b/data/osfamily/Darwin.yaml
@@ -1,0 +1,5 @@
+---
+vsts_agent::agent::package_src: 'https://vstsagentpackage.azureedge.net/agent/2.140.0/vsts-agent-osx-x64-2.140.0.tar.gz'
+vsts_agent::agent::package_sha512: '427b3c814a27242e05bcb8b189ff737ea92fda6cb02de2ee7b7c79c345fbe913d4af7abae67923e3ea798a622e92438531d7f8b51643b0cc5d46610b8c0ad0ec'
+vsts_agent::agent::archive_name: 'agent.tar.gz'
+vsts_agent::agent::config_script: 'config.sh'


### PR DESCRIPTION
On macOS, the VSTS Agent runs in the context of a logged in user (to support UI tests), and the service is controlled by a _user_ launch agent. Puppet's built in `service` resource can't manage user services but I was able to manually invoke `launchctl` to get that part working.

Open questions on some things, such as whether this module should try to manage the macOS user if it's absent. 

Feedback wanted. Thanks!