### PR TITLE
Remove PowerShell 5 dependency for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ At this time, only agent installation is handled. Configuration changes (e.g. ad
 
 All dependencies for the VSTS agent must be installed prior to using this module.
 
-On Windows, PowerShell >= 5 is required.
+On Windows, the System.IO.Compression.FileSystem .NET assembly must be available.
 
 If you are unable to download packages from the internet (either directly or through a proxy), you will need a locally accessible copy of the agent.
 

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -162,21 +162,19 @@ define vsts_agent::agent (
             require => File[$install_path_parent],
         }
 
-        # Requires PowerShell >= 5 (alternative to depending on 7z)
         archive {"${install_path}/${archive_name}":
-            ensure          => present,
-            extract         => true,
-            extract_path    => $install_path,
-            extract_command => "PowerShell -Command \"Expand-Archive -Path %s -DestinationPath ${install_path}\"",
-            source          => $package_src,
-            checksum        => $package_sha512,
-            checksum_type   => 'sha512',
-            creates         => "${install_path}/${config_script}",
-            proxy_type      => $proxy_type,
-            proxy_server    => $proxy_server,
-            user            => $service_user,
-            group           => $service_group,
-            require         => File[$install_path],
+            ensure        => present,
+            extract       => true,
+            extract_path  => $install_path,
+            source        => $package_src,
+            checksum      => $package_sha512,
+            checksum_type => 'sha512',
+            creates       => "${install_path}/${config_script}",
+            proxy_type    => $proxy_type,
+            proxy_server  => $proxy_server,
+            user          => $service_user,
+            group         => $service_group,
+            require       => File[$install_path],
         }
 
         acl {$install_path:

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppet-archive",
-      "version_requirement": ">=3.1.0"
+      "version_requirement": ">=3.2.0"
     },
     {
       "name": "AlexCline-dirtree",


### PR DESCRIPTION
The archive module's 3.2.0 release automatically falls back to PowerShell (using System.IO.Compression.FileSystem) when 7z is not
available. PowerShell 5 is not required.

Resolves #11