### PR TITLE
Windows service startup type - default to auto

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,5 +1,5 @@
 ---
-azure_pipelines::agent::package_src: 'https://vstsagentpackage.azureedge.net/agent/2.144.0/vsts-agent-linux-x64-2.144.0.tar.gz'
-azure_pipelines::agent::package_sha512: 'a0064b23bca664112debb08bbf9cbb0f394c66931c7c3fdc7f21d0c9ceb51cf1db75c74f1e5fe5ae454d2df1e035d878c35a4cf7139b9f2a0a80a70a98fa8f5b'
+azure_pipelines::agent::package_src: 'https://vstsagentpackage.azureedge.net/agent/2.163.1/vsts-agent-linux-x64-2.163.1.tar.gz'
+azure_pipelines::agent::package_sha512: '971dd242d077a869c6a28d7eedfbcc325598091fb9bff8b2cd364a9c82889fdc734a7b509f89e8cbecc0d4a6b0c2aa99b6817106258e75379eedf5f75697e6a8'
 azure_pipelines::agent::archive_name: 'agent.tar.gz'
 azure_pipelines::agent::config_script: 'config.sh'

--- a/data/osfamily/Darwin.yaml
+++ b/data/osfamily/Darwin.yaml
@@ -1,5 +1,5 @@
 ---
-azure_pipelines::agent::package_src: 'https://vstsagentpackage.azureedge.net/agent/2.144.0/vsts-agent-osx-x64-2.144.0.tar.gz'
-azure_pipelines::agent::package_sha512: '04ef95a6b579cb9b342565466475e6803a74f6394a4df1a1d6e65876787f01f97298fc65c9f9f2edaa3a7e130f18d29beb06bc80a819389068b698af347422ea'
+azure_pipelines::agent::package_src: 'https://vstsagentpackage.azureedge.net/agent/2.163.1/vsts-agent-osx-x64-2.163.1.tar.gz'
+azure_pipelines::agent::package_sha512: '2ade949837bc5902f9a93b45bf7c33f854bfadeaac92da30e5f9fa11cc627ea72ee71114d33c8e6dc7568bbdca773d1d84353ffa44b70933cb2f742695ba9d0f'
 azure_pipelines::agent::archive_name: 'agent.tar.gz'
 azure_pipelines::agent::config_script: 'config.sh'

--- a/data/osfamily/windows.yaml
+++ b/data/osfamily/windows.yaml
@@ -1,5 +1,5 @@
 ---
-azure_pipelines::agent::package_src: 'https://vstsagentpackage.azureedge.net/agent/2.144.0/vsts-agent-win-x64-2.144.0.zip'
-azure_pipelines::agent::package_sha512: '0c93c0c49167deb50f526c3c899abe95d764336278e960fd9a14048516d513821a60c9219a2427f166e221f9818db4df6533ffeb952897f7f7880c629792bc53'
+azure_pipelines::agent::package_src: 'https://vstsagentpackage.azureedge.net/agent/2.163.1/vsts-agent-win-x64-2.163.1.zip'
+azure_pipelines::agent::package_sha512: '0707463c1211e705fb35d59f03c65e9258951c54b1aef25c99a1ccceb93e410ed02e1a2db486c235723eb6ebb92484ed1e2666efe381bc66ce40247b71613f03'
 azure_pipelines::agent::archive_name: 'agent.zip'
 azure_pipelines::agent::config_script: 'config.cmd'

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -2,12 +2,13 @@
 #
 # @example
 #  azure_pipelines::agent { 'testagent':
-#      install_path       => '/opt/azure_pipelines/testagent',
-#      token              => 'pat-token',
-#      instance_name      => 'instance-name',
-#      service_user       => 'vsts',
-#      service_group      => 'vsts',
-#      run_as_service     => true,
+#      install_path         => '/opt/azure_pipelines/testagent',
+#      token                => 'pat-token',
+#      instance_name        => 'instance-name',
+#      service_user         => 'vsts',
+#      service_group        => 'vsts',
+#      run_as_service       => true,
+#      service_startup_type => 'true',
 #  }
 #
 # @param install_path
@@ -59,6 +60,8 @@
 #   Accept the TEE end user license agreement.
 # @param run_as_service
 #   Configure the agent to run as a service.
+# @param service_startup_type
+#   Configure the startup type for the service (see https://puppet.com/docs/puppet/latest/types/service.html#service-attribute-enable)
 # @param run_as_auto_logon
 #   Configure auto logon and run the agent on startup.
 # @param windows_logon_account
@@ -114,6 +117,7 @@ define azure_pipelines::agent (
     Optional[String[1]] $work = undef,
     Boolean $accept_tee_eula = false,
     Boolean $run_as_service = false,
+    Optional[String[1]] $service_startup_type = 'automatic',
     Boolean $run_as_auto_logon = false,
     Optional[String[1]] $windows_logon_account = $service_user,
     Optional[String[1]] $windows_logon_password = undef,
@@ -343,7 +347,7 @@ define azure_pipelines::agent (
         if $manage_service {
             service {"vstsagent.${instance_name}.${agent_name}":
                 ensure  => 'running',
-                enable  => true,
+                enable  => $service_startup_type,
                 require => Exec["${install_path}/${config_script}"],
             }
         }
@@ -365,6 +369,7 @@ define azure_pipelines::agent (
             if $manage_service {
                 service {"vsts.agent.${instance_name}.${agent_name}.service":
                     ensure  => 'running',
+                    enable  => $service_startup_type,
                     require => Exec["${install_path}/svc.sh install ${service_user}"],
                 }
             }

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -117,7 +117,7 @@ define azure_pipelines::agent (
     Optional[String[1]] $work = undef,
     Boolean $accept_tee_eula = false,
     Boolean $run_as_service = false,
-    Optional[String[1]] $service_startup_type = 'automatic',
+    Optional[String[1]] $service_startup_type = 'true',
     Boolean $run_as_auto_logon = false,
     Optional[String[1]] $windows_logon_account = $service_user,
     Optional[String[1]] $windows_logon_password = undef,

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -343,6 +343,7 @@ define azure_pipelines::agent (
         if $manage_service {
             service {"vstsagent.${instance_name}.${agent_name}":
                 ensure  => 'running',
+                enable  => true,
                 require => Exec["${install_path}/${config_script}"],
             }
         }


### PR DESCRIPTION
In testing, I found that the service refused to start when the startup type defaulted to "disabled" so added config to set the service startup to "automatic"

This could in theory also be added as an additional parameter to enable people to select "manual" startup type for the Windows service if they really want to?