### PR TITLE
Properly handle systemd escaped characters

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -363,8 +363,8 @@ define azure_pipelines::agent (
             }
             if $manage_service {
                 $escaped_dashes_in_service_name = regsubst("vsts.agent.${instance_name}.${agent_name}.service", '-', '\x2d', 'G')
-                $escaped_spaces_in_service_name = regsubst("vsts.agent.${instance_name}.${agent_name}.service", ' ', '\x20', 'G')
-                $escaped_slashes_in_service_name = regsubst("vsts.agent.${instance_name}.${agent_name}.service", '/', '-', 'G')
+                $escaped_spaces_in_service_name = regsubst($escaped_dashes_in_service_name, ' ', '\x20', 'G')
+                $escaped_slashes_in_service_name = regsubst($escaped_spaces_in_service_name, '/', '-', 'G')
                 $escaped_service_name = $escaped_slashes_in_service_name
                 service { $escaped_service_name:
                     ensure  => 'running',

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -356,13 +356,17 @@ define azure_pipelines::agent (
         }
         if $facts['kernel'] == 'Linux' and $run_as_service {
             exec {"${install_path}/svc.sh install ${service_user}":
-                creates => "/etc/systemd/system/vsts.agent.${instance_name}.${agent_name}.service",
+                onlyif  => "systemctl list-unit-files \"$(systemd-escape --path vsts.agent.${instance_name}.${agent_name}.service)\" | grep \"$(systemd-escape --path vsts.agent.${instance_name}.${agent_name}.service)\"",
                 user    => 'root',
                 cwd     => $install_path,
                 require => Exec["${install_path}/${config_script}"],
             }
             if $manage_service {
-                service {"vsts.agent.${instance_name}.${agent_name}.service":
+                $escaped_dashes_in_service_name = regsubst("vsts.agent.${instance_name}.${agent_name}.service", '-', '\x2d')
+                $escaped_spaces_in_service_name = regsubst("vsts.agent.${instance_name}.${agent_name}.service", ' ', '\x20')
+                $escaped_slashes_in_service_name = regsubst("vsts.agent.${instance_name}.${agent_name}.service", '/', '-')
+                $escaped_service_name = $escaped_slashes_in_service_name
+                service { $escaped_service_name:
                     ensure  => 'running',
                     require => Exec["${install_path}/svc.sh install ${service_user}"],
                 }

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -362,9 +362,9 @@ define azure_pipelines::agent (
                 require => Exec["${install_path}/${config_script}"],
             }
             if $manage_service {
-                $escaped_dashes_in_service_name = regsubst("vsts.agent.${instance_name}.${agent_name}.service", '-', '\x2d')
-                $escaped_spaces_in_service_name = regsubst("vsts.agent.${instance_name}.${agent_name}.service", ' ', '\x20')
-                $escaped_slashes_in_service_name = regsubst("vsts.agent.${instance_name}.${agent_name}.service", '/', '-')
+                $escaped_dashes_in_service_name = regsubst("vsts.agent.${instance_name}.${agent_name}.service", '-', '\x2d', 'G')
+                $escaped_spaces_in_service_name = regsubst("vsts.agent.${instance_name}.${agent_name}.service", ' ', '\x20', 'G')
+                $escaped_slashes_in_service_name = regsubst("vsts.agent.${instance_name}.${agent_name}.service", '/', '-', 'G')
                 $escaped_service_name = $escaped_slashes_in_service_name
                 service { $escaped_service_name:
                     ensure  => 'running',

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -18,7 +18,7 @@
 #   The name of the Azure Pipelines or VSTS account.
 # @param agent_name
 #   Unique name to identify the agent
-# @param package_src 
+# @param package_src
 #   Source of the agent installation package. Supports all URIs supported by the archive module.
 # @param package_sha512
 #   SHA-512 hash of the installation package, for verification.
@@ -78,7 +78,7 @@
 # @param deployment_group_tags
 #   Tags for a deployment group agent.
 # @param archive_name
-#   Destination filename for agent installation package. 
+#   Destination filename for agent installation package.
 # @param config_script
 #   Name of script file used to install the agent.
 # @param manage_service
@@ -355,14 +355,18 @@ define azure_pipelines::agent (
             require => Archive["${install_path}/${archive_name}"],
         }
         if $facts['kernel'] == 'Linux' and $run_as_service {
+            $service_name_part = $pool ? {
+                undef   => "${instance_name}.${agent_name}",
+                default => "${instance_name}.${pool}.${agent_name}"
+            }
             exec {"${install_path}/svc.sh install ${service_user}":
-                onlyif  => "systemctl list-unit-files \"$(systemd-escape --path vsts.agent.${instance_name}.${agent_name}.service)\" | grep \"$(systemd-escape --path vsts.agent.${instance_name}.${agent_name}.service)\"",
+                onlyif  => "/bin/systemctl list-unit-files \"$(/bin/systemd-escape --path vsts.agent.${service_name_part}.service)\" | /bin/grep \"$(/bin/systemd-escape --path vsts.agent.${service_name_part}.service)\"",
                 user    => 'root',
                 cwd     => $install_path,
                 require => Exec["${install_path}/${config_script}"],
             }
             if $manage_service {
-                $escaped_dashes_in_service_name = regsubst("vsts.agent.${instance_name}.${agent_name}.service", '-', '\x2d', 'G')
+                $escaped_dashes_in_service_name = regsubst("vsts.agent.${service_name_part}.service", '-', '\x2d', 'G')
                 $escaped_spaces_in_service_name = regsubst($escaped_dashes_in_service_name, ' ', '\x20', 'G')
                 $escaped_slashes_in_service_name = regsubst($escaped_spaces_in_service_name, '/', '-', 'G')
                 $escaped_service_name = $escaped_slashes_in_service_name


### PR DESCRIPTION
As part of the service installation process, svc.sh runs the agent name through the systemd-escape utility, which can modify the expected name of the service, causing this exec to run even though the service is already installed, and preventing the managed service from running. This commit fixes that problem.