### PR TITLE
Upgrade to latest vsts linux installer and add validation for bad chars

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,5 +1,5 @@
 ---
-azure_pipelines::agent::package_src: 'https://vstsagentpackage.azureedge.net/agent/2.144.0/vsts-agent-linux-x64-2.144.0.tar.gz'
-azure_pipelines::agent::package_sha512: 'a0064b23bca664112debb08bbf9cbb0f394c66931c7c3fdc7f21d0c9ceb51cf1db75c74f1e5fe5ae454d2df1e035d878c35a4cf7139b9f2a0a80a70a98fa8f5b'
+azure_pipelines::agent::package_src: 'https://vstsagentpackage.azureedge.net/agent/2.166.4/vsts-agent-linux-x64-2.166.4.tar.gz'
+azure_pipelines::agent::package_sha512: '45125e6ad2f7f4fd94a7dea936f2e87de2b623e0e2b250a9715f1ace9eb57aaed788fba17b80d4ee4037770223cacece48a4af596abc47db625c28a3efc7937a'
 azure_pipelines::agent::archive_name: 'agent.tar.gz'
 azure_pipelines::agent::config_script: 'config.sh'


### PR DESCRIPTION
Latest linux installer adds escaping of the systemd unit filename via `systemd-escape --path` which screws things up for the optimistic **service** naming.  This PR ensures that the issue is caught early.

Alternatives:
* Perform the \x2 escaping for dashes and hope that backslashes will work consistently in puppet's service resource (I'd rather not)
* Do not validate agent_name.  Instead, always do `regsubst($agent_name, '-', '_', 'G')`.  (possibly disruptive)

TBH I haven't considered other possible bad chars, but I figured that dashes would be fairly common.